### PR TITLE
Improve tab rename and gradient styling

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -24,22 +24,6 @@ body {
   background: transparent;
 }
 
-#app::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  padding: 2px;
-  border-radius: 12px;
-  background: var(--border-gradient);
-  -webkit-mask:
-    linear-gradient(#fff 0 0) content-box,
-    linear-gradient(#fff 0 0);
-  -webkit-mask-composite: xor;
-          mask-composite: exclude;
-  pointer-events: none;
-  z-index: 1000;
-}
-
 #app > * {
   position: relative;
   z-index: 0;
@@ -160,6 +144,21 @@ body {
   box-shadow: 0 2px 6px rgba(0,0,0,0.4);
 }
 
+.tab.active::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  padding: 2px 0 2px 2px;
+  border-radius: 8px 0 0 8px;
+  background: var(--border-gradient);
+  -webkit-mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+          mask-composite: exclude;
+  pointer-events: none;
+}
+
 .tab.active::after {
   content: '';
   position: absolute;
@@ -188,6 +187,8 @@ body {
   padding: 2px 4px;
   font-size: inherit;
   border-radius: 4px;
+  box-sizing: border-box;
+  outline: none;
 }
 
 .tab .close-tab {
@@ -239,7 +240,27 @@ body {
   overflow: hidden;
 }
 
+#note-area::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  padding: 2px;
+  border-radius: 12px;
+  background: var(--border-gradient);
+  -webkit-mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+          mask-composite: exclude;
+  pointer-events: none;
+  z-index: 1;
+}
+
 #note-area.attached {
+  border-top-left-radius: 0;
+}
+
+#note-area.attached::before {
   border-top-left-radius: 0;
 }
 


### PR DESCRIPTION
## Summary
- Remove global gradient border and apply gradient to editor pane and active tab
- Prevent orange outline and layout glitch when renaming tabs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb7421bbcc832fa30fce04f95b9a5e