### PR TITLE
Add configurable window themes

### DIFF
--- a/main.js
+++ b/main.js
@@ -18,8 +18,8 @@ function createWindow() {
     icon: path.join(__dirname, 'media', 'AuraNote.ico'),
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
-      nodeIntegration: true,
-      contextIsolation: false
+      nodeIntegration: false,
+      contextIsolation: true
     }
   });
 

--- a/main.js
+++ b/main.js
@@ -60,3 +60,25 @@ ipcMain.handle('window-control', (event, action) => {
       break;
   }
 });
+
+ipcMain.handle('set-theme', (event, theme) => {
+  switch (theme) {
+    case 'light-mica':
+      mainWindow.setLightTheme();
+      mainWindow.setMicaEffect();
+      break;
+    case 'acrylic':
+      mainWindow.setDarkTheme();
+      if (mainWindow.setMicaAcrylicEffect) {
+        mainWindow.setMicaAcrylicEffect();
+      } else {
+        mainWindow.setAcrylic();
+      }
+      break;
+    case 'dark-mica':
+    default:
+      mainWindow.setDarkTheme();
+      mainWindow.setMicaEffect();
+      break;
+  }
+});

--- a/preload.js
+++ b/preload.js
@@ -1,5 +1,6 @@
 const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('api', {
-  windowControl: (action) => ipcRenderer.invoke('window-control', action)
+  windowControl: (action) => ipcRenderer.invoke('window-control', action),
+  setTheme: (theme) => ipcRenderer.invoke('set-theme', theme)
 });

--- a/src/index.html
+++ b/src/index.html
@@ -116,6 +116,16 @@
             <option value="linear-gradient(135deg,#d7b8ff,#e5d2ff)">Lilac</option>
             <option value="linear-gradient(135deg,#c4f0d9,#e3f9e9)">Mint</option>
             <option value="linear-gradient(135deg,#d0d7e2,#e5eaf1)">Slate</option>
+            <option value="linear-gradient(135deg,#ff00ff,#00ffff)">Neon</option>
+            <option value="linear-gradient(135deg,#ffce00,#ff7300)">Citrus</option>
+            <option value="linear-gradient(135deg,#00ff95,#00bfff)">Tropical</option>
+            <option value="linear-gradient(135deg,#f000ff,#ff6600)">Fusion</option>
+            <option value="linear-gradient(135deg,#ff0033,#ff7700)">Ember</option>
+            <option value="linear-gradient(135deg,#00f260,#0575e6)">Cyber</option>
+            <option value="linear-gradient(135deg,#ffee00,#00eaff)">Volt</option>
+            <option value="linear-gradient(135deg,#7f00ff,#e100ff)">Galaxy</option>
+            <option value="linear-gradient(135deg,#ff616f,#ffb88c)">Coral</option>
+            <option value="linear-gradient(135deg,#ff512f,#f09819)">Sunrise</option>
           </select>
           <div id="gradient-preview" class="gradient-preview"></div>
         </div>

--- a/src/index.html
+++ b/src/index.html
@@ -60,7 +60,7 @@
   }
   </script>
 </head>
-<body>
+<body class="theme-dark">
   <div id="app">
     <div id="titlebar">
       <span id="app-title">AuraNote</span>
@@ -88,6 +88,14 @@
     <div id="settings-view" class="hidden">
       <button id="close-settings" title="Close settings">×</button>
       <h2>Settings</h2>
+      <div class="setting">
+        <label for="theme-select">Theme:</label>
+        <select id="theme-select">
+          <option value="dark-mica">Dark Mica</option>
+          <option value="light-mica">Light Mica</option>
+          <option value="acrylic">Acrylic</option>
+        </select>
+      </div>
       <div class="setting">
         <label for="gradient-select">Gradient Theme:</label>
         <div class="gradient-row">

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -12,6 +12,7 @@ settingsView.classList.add('hidden');
 const gradientSelect = document.getElementById('gradient-select');
 const gradientPreview = document.getElementById('gradient-preview');
 const fontSelect = document.getElementById('font-select');
+const themeSelect = document.getElementById('theme-select');
 const logsBtn = document.getElementById('logs-btn');
 const logPanel = document.getElementById('log-panel');
 const logOutput = document.getElementById('log-output');
@@ -32,10 +33,30 @@ if (savedFont) {
   document.body.style.setProperty('--app-font', "'" + savedFont + "', sans-serif");
 }
 
+function applyTheme(theme, persist = true) {
+  document.body.classList.remove('theme-dark', 'theme-light', 'theme-acrylic');
+  if (theme === 'light-mica') {
+    document.body.classList.add('theme-light');
+  } else if (theme === 'acrylic') {
+    document.body.classList.add('theme-acrylic');
+  } else {
+    document.body.classList.add('theme-dark');
+  }
+  window.api.setTheme(theme);
+  if (persist) {
+    localStorage.setItem('theme', theme);
+  }
+}
+
+const savedTheme = localStorage.getItem('theme') || 'dark-mica';
+themeSelect.value = savedTheme;
+applyTheme(savedTheme, false);
+
 function syncDropdownWidths() {
   const width = gradientSelect.offsetWidth;
   if (width) {
     fontSelect.style.width = `${width}px`;
+    themeSelect.style.width = `${width}px`;
   }
 }
 syncDropdownWidths();
@@ -325,6 +346,10 @@ gradientSelect.addEventListener('change', (e) => {
 fontSelect.addEventListener('change', (e) => {
   document.body.style.setProperty('--app-font', "'" + e.target.value + "', sans-serif");
   localStorage.setItem('font', e.target.value);
+});
+
+themeSelect.addEventListener('change', (e) => {
+  applyTheme(e.target.value);
 });
 
 const minBtn = document.getElementById('min-btn');

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -47,7 +47,9 @@ function applyTheme(theme, persist = true) {
   } else {
     document.body.classList.add('theme-dark');
   }
-  window.api.setTheme(theme);
+  if (window.api?.setTheme) {
+    window.api.setTheme(theme);
+  }
   if (persist) {
     localStorage.setItem('theme', theme);
   }
@@ -77,7 +79,7 @@ noteArea.addEventListener('click', async (e) => {
   view.focus();
 });
 
-const isDev = process.env.NODE_ENV !== 'production';
+const isDev = typeof process !== 'undefined' && process.env?.NODE_ENV !== 'production';
 if (isDev) {
   function formatLogArg(a) {
     if (a instanceof Error) {
@@ -361,8 +363,8 @@ const minBtn = document.getElementById('min-btn');
 const maxBtn = document.getElementById('max-btn');
 const closeBtn = document.getElementById('close-btn');
 
-minBtn.addEventListener('click', () => window.api.windowControl('minimize'));
-maxBtn.addEventListener('click', () => window.api.windowControl('maximize'));
+minBtn.addEventListener('click', () => window.api?.windowControl('minimize'));
+maxBtn.addEventListener('click', () => window.api?.windowControl('maximize'));
 closeBtn.addEventListener('click', () => {
   if (window.api?.windowControl) {
     window.api.windowControl('close');

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,4 +1,9 @@
-let tabs = JSON.parse(localStorage.getItem('tabs') || '[]');
+let tabs = [];
+try {
+  tabs = JSON.parse(localStorage.getItem('tabs') || '[]');
+} catch {
+  localStorage.removeItem('tabs');
+}
 let currentTab = null;
 
 const tabList = document.getElementById('tab-list');

--- a/src/styles.css
+++ b/src/styles.css
@@ -8,10 +8,77 @@ html, body {
   --app-font: 'Poppins', sans-serif;
 }
 
+body.theme-dark {
+  --text-color: #fff;
+  --titlebar-bg: rgba(0,0,0,0.2);
+  --main-bg: rgba(0,0,0,0.2);
+  --tab-hover-bg: rgba(255,255,255,0.07);
+  --tab-active-bg: #303030;
+  --rename-bg: rgba(0,0,0,0.4);
+  --add-tab-hover-bg: rgba(255,255,255,0.05);
+  --add-tab-active-bg: rgba(255,255,255,0.1);
+  --note-bg: #303030;
+  --settings-bg: rgba(20,20,20,0.85);
+  --select-bg: #111;
+  --select-text: #fff;
+  --select-border: #555;
+  --select-option-bg: #111;
+  --btn-hover-bg: rgba(255,255,255,0.1);
+  --scrollbar-thumb: rgba(255,255,255,0.2);
+  --scrollbar-thumb-hover: rgba(255,255,255,0.3);
+  --log-bg: rgba(0,0,0,0.8);
+  --editor-pre-bg: rgba(0,0,0,0.3);
+}
+
+body.theme-light {
+  --text-color: #000;
+  --titlebar-bg: rgba(255,255,255,0.7);
+  --main-bg: rgba(255,255,255,0.6);
+  --tab-hover-bg: rgba(0,0,0,0.07);
+  --tab-active-bg: #e0e0e0;
+  --rename-bg: rgba(0,0,0,0.1);
+  --add-tab-hover-bg: rgba(0,0,0,0.05);
+  --add-tab-active-bg: rgba(0,0,0,0.1);
+  --note-bg: #f5f5f5;
+  --settings-bg: rgba(255,255,255,0.85);
+  --select-bg: #eee;
+  --select-text: #000;
+  --select-border: #aaa;
+  --select-option-bg: #fff;
+  --btn-hover-bg: rgba(0,0,0,0.1);
+  --scrollbar-thumb: rgba(0,0,0,0.3);
+  --scrollbar-thumb-hover: rgba(0,0,0,0.4);
+  --log-bg: rgba(255,255,255,0.8);
+  --editor-pre-bg: rgba(0,0,0,0.1);
+}
+
+body.theme-acrylic {
+  --text-color: #fff;
+  --titlebar-bg: rgba(0,0,0,0.4);
+  --main-bg: rgba(0,0,0,0.4);
+  --tab-hover-bg: rgba(255,255,255,0.1);
+  --tab-active-bg: rgba(0,0,0,0.6);
+  --rename-bg: rgba(0,0,0,0.5);
+  --add-tab-hover-bg: rgba(255,255,255,0.1);
+  --add-tab-active-bg: rgba(255,255,255,0.2);
+  --note-bg: rgba(0,0,0,0.6);
+  --settings-bg: rgba(30,30,30,0.75);
+  --select-bg: #222;
+  --select-text: #fff;
+  --select-border: #555;
+  --select-option-bg: #222;
+  --btn-hover-bg: rgba(255,255,255,0.2);
+  --scrollbar-thumb: rgba(255,255,255,0.3);
+  --scrollbar-thumb-hover: rgba(255,255,255,0.4);
+  --log-bg: rgba(0,0,0,0.8);
+  --editor-pre-bg: rgba(0,0,0,0.4);
+}
+
 body {
   font-family: var(--app-font);
   background: transparent;
   overflow: hidden;
+  color: var(--text-color);
 }
 
 #app {
@@ -37,8 +104,8 @@ body {
   padding-right: 0;
   user-select: none;
   -webkit-app-region: drag;
-  color: #fff;
-  background: rgba(0,0,0,0.2);
+  color: var(--text-color);
+  background: var(--titlebar-bg);
   border-top-left-radius: 12px;
   border-top-right-radius: 12px;
 }
@@ -60,7 +127,7 @@ body {
 #logs-btn {
   background: transparent;
   border: none;
-  color: #fff;
+  color: var(--text-color);
   font-size: 16px;
   cursor: pointer;
 }
@@ -74,7 +141,7 @@ body {
   height: 34px;
   border: none;
   background: transparent;
-  color: #fff;
+  color: var(--text-color);
   cursor: pointer;
   -webkit-app-region: no-drag;
   display: flex;
@@ -88,7 +155,7 @@ body {
 }
 
 .window-btn:hover {
-  background: rgba(255,255,255,0.1);
+  background: var(--btn-hover-bg);
 }
 
 #close-btn:hover {
@@ -99,7 +166,7 @@ body {
   flex: 1;
   display: flex;
   overflow: hidden;
-  background: rgba(0,0,0,0.2);
+  background: var(--main-bg);
   border-bottom-left-radius: 12px;
   border-bottom-right-radius: 12px;
 }
@@ -124,7 +191,7 @@ body {
   align-items: center;
   padding: 6px 14px 6px 20px;
   margin: 0 4px 4px 4px;
-  color: #fff;
+  color: var(--text-color);
   cursor: pointer;
   border-radius: 8px;
   transition: background 0.2s, box-shadow 0.2s;
@@ -134,11 +201,11 @@ body {
 }
 
 .tab:hover {
-  background: rgba(255,255,255,0.07);
+  background: var(--tab-hover-bg);
 }
 
  .tab.active {
-  background: #303030;
+  background: var(--tab-active-bg);
   margin-right: 4px;
   border-radius: 8px;
   box-shadow: 0 2px 6px rgba(0,0,0,0.4);
@@ -168,9 +235,9 @@ body {
 
 .rename-input {
   flex: 1;
-  background: rgba(0,0,0,0.4);
+  background: var(--rename-bg);
   border: none;
-  color: #fff;
+  color: var(--text-color);
   padding: 2px 4px;
   font-size: inherit;
   border-radius: 4px;
@@ -183,7 +250,7 @@ body {
   opacity: 0;
   background: transparent;
   border: none;
-  color: #fff;
+  color: var(--text-color);
   cursor: pointer;
   font-size: 16px;
   padding: 0 4px;
@@ -200,7 +267,7 @@ body {
 #add-tab {
   border: none;
   background: transparent;
-  color: #fff;
+  color: var(--text-color);
   padding: 6px 14px 6px 20px;
   cursor: pointer;
   border-radius: 8px;
@@ -209,19 +276,19 @@ body {
 }
 
 #add-tab:hover {
-  background: rgba(255,255,255,0.05);
+  background: var(--add-tab-hover-bg);
 }
 
 #add-tab:active {
-  background: rgba(255,255,255,0.1);
+  background: var(--add-tab-active-bg);
 }
 
 #note-area {
   flex: 1;
   margin: 4px 10px 10px 8px;
-  background: #303030;
+  background: var(--note-bg);
   position: relative;
-  color: #fff;
+  color: var(--text-color);
   border-radius: 12px;
   box-shadow: 0 4px 10px rgba(0,0,0,0.4);
   overflow: hidden;
@@ -251,7 +318,7 @@ body {
   font-size: 14px;
   line-height: 1.4;
   background: transparent;
-  color: #fff;
+  color: var(--text-color);
   overflow: auto;
 }
 
@@ -282,13 +349,13 @@ body {
   right: 0;
   bottom: 0;
   padding: 30px;
-  color: #fff;
+  color: var(--text-color);
   display: flex;
   flex-direction: column;
   gap: 24px;
   overflow: auto;
   z-index: 1000;
-  background: rgba(20,20,20,0.85);
+  background: var(--settings-bg);
   backdrop-filter: blur(20px) saturate(180%);
   -webkit-backdrop-filter: blur(20px) saturate(180%);
 }
@@ -314,9 +381,9 @@ body {
 
 #settings-view select {
   padding: 8px;
-  background: #111;
-  color: #fff;
-  border: 1px solid #555;
+  background: var(--select-bg);
+  color: var(--select-text);
+  border: 1px solid var(--select-border);
   border-radius: 4px;
   font-size: 14px;
 }
@@ -328,8 +395,8 @@ body {
 }
 
 #settings-view select option {
-  background: #111;
-  color: #fff;
+  background: var(--select-option-bg);
+  color: var(--select-text);
 }
 
 
@@ -339,7 +406,7 @@ body {
   right: 12px;
   background: transparent;
   border: none;
-  color: #fff;
+  color: var(--text-color);
   font-size: 20px;
   cursor: pointer;
   padding: 4px;
@@ -354,14 +421,14 @@ body {
 .gradient-preview {
   width: 24px;
   height: 24px;
-  border: 1px solid #555;
+  border: 1px solid var(--select-border);
   border-radius: 4px;
 }
 
 /* Minimal dark scrollbars */
 * {
   scrollbar-width: thin;
-  scrollbar-color: rgba(255,255,255,0.2) transparent;
+  scrollbar-color: var(--scrollbar-thumb) transparent;
 }
 
 *::-webkit-scrollbar {
@@ -374,12 +441,12 @@ body {
 }
 
 *::-webkit-scrollbar-thumb {
-  background: rgba(255,255,255,0.2);
+  background: var(--scrollbar-thumb);
   border-radius: 3px;
 }
 
 *::-webkit-scrollbar-thumb:hover {
-  background: rgba(255,255,255,0.3);
+  background: var(--scrollbar-thumb-hover);
 }
 
 #log-panel {
@@ -388,8 +455,8 @@ body {
   right: 0;
   bottom: 0;
   height: 30%;
-  background: rgba(0,0,0,0.8);
-  color: #fff;
+  background: var(--log-bg);
+  color: var(--text-color);
   font-family: monospace;
   padding: 8px;
   overflow-y: auto;
@@ -409,7 +476,7 @@ body {
 }
 
 #editor pre {
-  background: rgba(0,0,0,0.3);
+  background: var(--editor-pre-bg);
   padding: 8px;
   border-radius: 6px;
   overflow: auto;

--- a/src/styles.css
+++ b/src/styles.css
@@ -32,15 +32,15 @@ body.theme-dark {
 
 body.theme-light {
   --text-color: #000;
-  --titlebar-bg: rgba(255,255,255,0.7);
-  --main-bg: rgba(255,255,255,0.6);
+  --titlebar-bg: rgba(255,255,255,0.45);
+  --main-bg: rgba(255,255,255,0.4);
   --tab-hover-bg: rgba(0,0,0,0.07);
-  --tab-active-bg: #e0e0e0;
+  --tab-active-bg: rgba(224,224,224,0.6);
   --rename-bg: rgba(0,0,0,0.1);
   --add-tab-hover-bg: rgba(0,0,0,0.05);
   --add-tab-active-bg: rgba(0,0,0,0.1);
-  --note-bg: #f5f5f5;
-  --settings-bg: rgba(255,255,255,0.85);
+  --note-bg: rgba(255,255,255,0.6);
+  --settings-bg: rgba(255,255,255,0.7);
   --select-bg: #eee;
   --select-text: #000;
   --select-border: #aaa;
@@ -48,8 +48,8 @@ body.theme-light {
   --btn-hover-bg: rgba(0,0,0,0.1);
   --scrollbar-thumb: rgba(0,0,0,0.3);
   --scrollbar-thumb-hover: rgba(0,0,0,0.4);
-  --log-bg: rgba(255,255,255,0.8);
-  --editor-pre-bg: rgba(0,0,0,0.1);
+  --log-bg: rgba(255,255,255,0.7);
+  --editor-pre-bg: rgba(0,0,0,0.08);
 }
 
 body.theme-acrylic {

--- a/src/styles.css
+++ b/src/styles.css
@@ -209,7 +209,6 @@ body {
   margin-right: 4px;
   border-radius: 8px;
   box-shadow: 0 2px 6px rgba(0,0,0,0.4);
-  z-index: 0;
 }
 
  .tab.active::before {
@@ -227,19 +226,6 @@ body {
   pointer-events: none;
   z-index: 1;
 }
-
- .tab.active::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  border-radius: 8px;
-  background: var(--border-gradient);
-  filter: blur(6px);
-  opacity: 0.6;
-  z-index: -1;
-  pointer-events: none;
- }
-
 .tab .title {
   flex: 1;
   overflow: hidden;
@@ -305,7 +291,7 @@ body {
   color: var(--text-color);
   border-radius: 12px;
   box-shadow: 0 4px 10px rgba(0,0,0,0.4);
-  overflow: visible;
+  overflow: hidden;
 }
 
 #note-area::before {
@@ -323,20 +309,6 @@ body {
   pointer-events: none;
   z-index: 1;
 }
-
-#note-area::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: 12px;
-  background: var(--border-gradient);
-  filter: blur(12px);
-  opacity: 0.5;
-  z-index: -1;
-  pointer-events: none;
-}
-
-
 #editor {
   height: 100%;
   padding: 10px;

--- a/src/styles.css
+++ b/src/styles.css
@@ -32,8 +32,8 @@ body.theme-dark {
 
 body.theme-light {
   --text-color: #000;
-  --titlebar-bg: rgba(255,255,255,0.45);
-  --main-bg: rgba(255,255,255,0.4);
+  --titlebar-bg: rgba(255,255,255,0.8);
+  --main-bg: rgba(255,255,255,0.55);
   --tab-hover-bg: rgba(0,0,0,0.07);
   --tab-active-bg: rgba(224,224,224,0.6);
   --rename-bg: rgba(0,0,0,0.1);
@@ -204,11 +204,12 @@ body {
   background: var(--tab-hover-bg);
 }
 
- .tab.active {
+.tab.active {
   background: var(--tab-active-bg);
   margin-right: 4px;
   border-radius: 8px;
   box-shadow: 0 2px 6px rgba(0,0,0,0.4);
+  z-index: 0;
 }
 
  .tab.active::before {
@@ -224,7 +225,20 @@ body {
   -webkit-mask-composite: xor;
           mask-composite: exclude;
   pointer-events: none;
+  z-index: 1;
 }
+
+ .tab.active::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 8px;
+  background: var(--border-gradient);
+  filter: blur(6px);
+  opacity: 0.6;
+  z-index: -1;
+  pointer-events: none;
+ }
 
 .tab .title {
   flex: 1;
@@ -291,7 +305,7 @@ body {
   color: var(--text-color);
   border-radius: 12px;
   box-shadow: 0 4px 10px rgba(0,0,0,0.4);
-  overflow: hidden;
+  overflow: visible;
 }
 
 #note-area::before {
@@ -308,6 +322,18 @@ body {
           mask-composite: exclude;
   pointer-events: none;
   z-index: 1;
+}
+
+#note-area::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 12px;
+  background: var(--border-gradient);
+  filter: blur(12px);
+  opacity: 0.5;
+  z-index: -1;
+  pointer-events: none;
 }
 
 


### PR DESCRIPTION
## Summary
- Add theme selector in settings to switch between Dark Mica, Light Mica, and Acrylic
- Implement IPC handler to apply selected theme effects in the main process
- Introduce CSS variables and styles for dark, light, and acrylic window themes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb8d71e728832f9cf7f959ae011923