### PR TITLE
Improve tab renaming and compact tab styling

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -316,23 +316,13 @@ function renderTabs() {
     tabEl.appendChild(titleSpan);
     tabEl.appendChild(closeBtn);
 
-    let clickTimer = null;
     tabEl.addEventListener('click', () => {
-      if (clickTimer) {
-        clearTimeout(clickTimer);
-        clickTimer = null;
-        if (currentTab?.id !== tab.id) {
-          switchTab(tab.id);
-          setTimeout(() => renameTab(tab.id), 0);
-        } else {
-          renameTab(tab.id);
-        }
-      } else {
-        clickTimer = setTimeout(() => {
-          if (currentTab?.id !== tab.id) switchTab(tab.id);
-          clickTimer = null;
-        }, 200);
-      }
+      if (currentTab?.id !== tab.id) switchTab(tab.id);
+    });
+
+    tabEl.addEventListener('dblclick', () => {
+      if (currentTab?.id !== tab.id) switchTab(tab.id);
+      renameTab(tab.id);
     });
 
     tabList.appendChild(tabEl);

--- a/src/styles.css
+++ b/src/styles.css
@@ -174,33 +174,33 @@ body {
 }
 
 #tabs {
-  width: 170px;
+  width: 150px;
   display: flex;
   flex-direction: column;
   overflow: visible;
   border-bottom-left-radius: 12px;
-  margin: 12px 0 12px 5px;
+  margin: 8px 0 8px 5px;
 }
 
 #tab-list {
   flex: 1;
   overflow-y: auto;
   overflow-x: hidden;
-  padding: 10px 10px 10px 0px;
+  padding: 6px 6px 6px 0;
 }
 
 .tab {
   display: flex;
   align-items: center;
-  padding: 10px 18px 10px 24px;
-  margin: 0 8px 8px 8px;
+  padding: 6px 14px 6px 20px;
+  margin: 0 6px 6px 6px;
   color: var(--text-color);
   cursor: pointer;
   border-radius: 8px;
   transition: background 0.2s, box-shadow 0.2s;
   position: relative;
   background: transparent;
-  gap: 8px;
+  gap: 6px;
 }
 
 .tab:hover {
@@ -247,6 +247,8 @@ body {
   border-radius: 4px;
   box-sizing: border-box;
   outline: none;
+  width: 100%;
+  min-width: 0;
 }
 
 .tab .close-tab {
@@ -272,7 +274,7 @@ body {
   border: none;
   background: transparent;
   color: var(--text-color);
-  padding: 6px 14px 6px 20px;
+  padding: 4px 10px 4px 14px;
   cursor: pointer;
   border-radius: 8px;
   transition: background 0.2s;


### PR DESCRIPTION
## Summary
- Fix tab renaming input to stay within sidebar and handle long names
- Use double-click event for renaming tabs
- Reduce tab width and padding for a more compact sidebar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbc7e4d3a4832fb6be81df5172d5c1