### PR TITLE
Add tab folders, drag-and-drop, and keyboard shortcuts

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -77,7 +77,7 @@ tabList.addEventListener('drop', (e) => {
 });
 
 tabsContainer.addEventListener('contextmenu', (e) => {
-  if (e.target.closest('.tab')) return;
+  if (e.target.closest('.tab') || e.target.closest('.folder')) return;
   e.preventDefault();
   showMenu(tabBarContextMenu, e.pageX, e.pageY, [
     { label: 'New Folder', action: () => createFolder() }
@@ -559,6 +559,7 @@ function renderTabs() {
     });
     header.addEventListener('contextmenu', (e) => {
       e.preventDefault();
+      e.stopPropagation();
       const x = e.pageX;
       const y = e.pageY;
       showMenu(tabContextMenu, x, y, [
@@ -586,8 +587,8 @@ function renderTabs() {
         moveTabToFolder(draggedTabId, folder.id);
       } else if (draggedFolderId && draggedFolderId !== folder.id) {
         const draggedIndex = folders.findIndex(f => f.id === draggedFolderId);
-        const targetIndex = folders.findIndex(f => f.id === folder.id);
         const [dragged] = folders.splice(draggedIndex, 1);
+        const targetIndex = folders.findIndex(f => f.id === folder.id);
         folders.splice(targetIndex, 0, dragged);
         saveTabs();
         renderTabs();

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -60,7 +60,7 @@ tabsContainer.addEventListener('contextmenu', (e) => {
   if (e.target.closest('.tab')) return;
   e.preventDefault();
   showMenu(tabBarContextMenu, e.pageX, e.pageY, [
-    { label: 'New Folder', action: () => { const name = prompt('Folder name:'); if (name) createFolder(name); } }
+    { label: 'New Folder', action: () => createFolder() }
   ]);
 });
 const noteArea = document.getElementById('note-area');
@@ -389,15 +389,21 @@ function createTabElement(tab) {
     e.preventDefault();
     const x = e.pageX;
     const y = e.pageY;
-    showMenu(tabContextMenu, x, y, [
+    const items = [
       { label: 'Rename', action: () => { hideMenus(); renameTab(tab.id); } },
-      { label: 'Delete', action: () => { hideMenus(); closeTab(tab.id); } },
-      { label: 'Move to Folder', action: () => {
-          const items = [{ label: 'Root', action: () => { hideMenus(); moveTabToFolder(tab.id, null); } }];
-          folders.forEach(f => items.push({ label: f.title, action: () => { hideMenus(); moveTabToFolder(tab.id, f.id); } }));
-          showMenu(tabContextMenu, x, y, items);
-        } },
-    ]);
+      { label: 'Delete', action: () => { hideMenus(); closeTab(tab.id); } }
+    ];
+    if (folders.length > 0) {
+      items.push({
+        label: 'Move to Folder',
+        action: () => {
+          const moveItems = [{ label: 'Root', action: () => { hideMenus(); moveTabToFolder(tab.id, null); } }];
+          folders.forEach(f => moveItems.push({ label: f.title, action: () => { hideMenus(); moveTabToFolder(tab.id, f.id); } }));
+          showMenu(tabContextMenu, x, y, moveItems);
+        }
+      });
+    }
+    showMenu(tabContextMenu, x, y, items);
   });
 
   tabEl.addEventListener('dragstart', (e) => {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -339,7 +339,7 @@ function createFolder(name) {
     name = base + index;
   }
   const id = Date.now().toString() + '-f';
-  folders.push({ id, title: name });
+  folders.push({ id, title: name, collapsed: false });
   saveTabs();
   renderTabs();
 }
@@ -452,10 +452,32 @@ function renderTabs() {
     const folderEl = document.createElement('div');
     folderEl.className = 'folder';
     folderEl.dataset.id = folder.id;
+    if (folder.collapsed) folderEl.classList.add('collapsed');
 
     const header = document.createElement('div');
     header.className = 'folder-header';
-    header.textContent = folder.title;
+
+    const arrow = document.createElement('span');
+    arrow.className = 'folder-arrow';
+    arrow.textContent = folder.collapsed ? '▶' : '▼';
+    header.appendChild(arrow);
+
+    const icon = document.createElement('span');
+    icon.className = 'folder-icon';
+    icon.textContent = '📁';
+    header.appendChild(icon);
+
+    const title = document.createElement('span');
+    title.className = 'folder-title';
+    title.textContent = folder.title;
+    header.appendChild(title);
+
+    header.addEventListener('click', () => {
+      folder.collapsed = !folder.collapsed;
+      saveTabs();
+      renderTabs();
+    });
+
     folderEl.appendChild(header);
 
     const container = document.createElement('div');

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -546,9 +546,6 @@ function createTab(title) {
 
 function renderTabs() {
   tabList.innerHTML = '';
-  tabs.filter(t => !t.folderId).forEach(tab => {
-    tabList.appendChild(createTabElement(tab));
-  });
   folders.forEach(folder => {
     const folderEl = document.createElement('div');
     folderEl.className = 'folder';
@@ -675,6 +672,9 @@ function renderTabs() {
     });
     tabList.appendChild(folderEl);
     folderEl.appendChild(container);
+  });
+  tabs.filter(t => !t.folderId).forEach(tab => {
+    tabList.appendChild(createTabElement(tab));
   });
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -291,7 +291,23 @@ body {
 }
 
 .folder-icon {
-  font-size: 14px;
+  width: 14px;
+  height: 14px;
+  display: flex;
+}
+
+.folder-icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+body.theme-dark .folder-icon svg,
+body.theme-acrylic .folder-icon svg {
+  fill: #fff;
+}
+
+body.theme-light .folder-icon svg {
+  fill: #000;
 }
 
 .folder-tabs {
@@ -396,6 +412,32 @@ body {
 #editor:focus,
 #editor .ProseMirror:focus {
   outline: none;
+}
+
+.toast {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--note-bg);
+  color: var(--text-color);
+  padding: 8px 16px;
+  border: 1px solid var(--tab-active-bg);
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.3);
+  z-index: 10000;
+  opacity: 0;
+  animation: fadein 0.3s forwards, fadeout 0.3s 2.5s forwards;
+}
+
+@keyframes fadein {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes fadeout {
+  from { opacity: 1; }
+  to { opacity: 0; }
 }
 
 #editor * {

--- a/src/styles.css
+++ b/src/styles.css
@@ -208,7 +208,7 @@ body {
 }
 
 .tab.active {
-  background: var(--tab-active-bg);
+  background: var(--tab-hover-bg);
   margin-right: 4px;
   border-radius: 8px;
   box-shadow: inset 0 0 0 1px rgba(255,255,255,0.1), 0 2px 4px rgba(0,0,0,0.3);
@@ -275,14 +275,31 @@ body {
 }
 
 .folder-header {
-  padding: 6px 14px 6px 20px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
   margin: 0 0 4px 0;
   border-radius: 8px;
-  background: var(--tab-active-bg);
+  background: var(--tab-hover-bg);
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.folder-arrow {
+  font-size: 12px;
+}
+
+.folder-icon {
+  font-size: 14px;
 }
 
 .folder-tabs {
-  margin-left: 10px;
+  margin-left: 20px;
+}
+
+.folder.collapsed .folder-tabs {
+  display: none;
 }
 
 .context-menu {

--- a/src/styles.css
+++ b/src/styles.css
@@ -318,6 +318,23 @@ body.theme-light .folder-icon svg {
   display: none;
 }
 
+.tab.dragging,
+.folder.dragging {
+  opacity: 0.5;
+}
+
+.folder-header.drag-over {
+  outline: 2px dashed var(--text-color);
+}
+
+.drag-indicator {
+  height: 2px;
+  background: var(--text-color);
+  margin: 2px 6px;
+  border-radius: 1px;
+  pointer-events: none;
+}
+
 .context-menu {
   position: absolute;
   background: var(--note-bg);

--- a/src/styles.css
+++ b/src/styles.css
@@ -270,6 +270,44 @@ body {
   opacity: 1;
 }
 
+.folder {
+  margin: 0 6px 6px 6px;
+}
+
+.folder-header {
+  padding: 6px 14px 6px 20px;
+  margin: 0 0 4px 0;
+  border-radius: 8px;
+  background: var(--tab-active-bg);
+}
+
+.folder-tabs {
+  margin-left: 10px;
+}
+
+.context-menu {
+  position: absolute;
+  background: var(--note-bg);
+  border: 1px solid var(--tab-active-bg);
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.3);
+  z-index: 10000;
+}
+
+.context-menu.hidden {
+  display: none;
+}
+
+.context-menu-item {
+  padding: 6px 12px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.context-menu-item:hover {
+  background: var(--tab-hover-bg);
+}
+
 #add-tab {
   border: none;
   background: transparent;


### PR DESCRIPTION
## Summary
- Support organizing tabs into folders with drag-and-drop moving and context menu actions (rename, delete, move).
- Provide tab bar context menu to create folders and added keyboard shortcuts for tab creation and cycling.
- Style folders and context menus for a consistent look.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbcc30e868832fb1c12962042e1b5f