### PR TITLE
Fix icon loading and add Kurzgesagt theme

### DIFF
--- a/main.js
+++ b/main.js
@@ -17,7 +17,7 @@ function createWindow() {
     show: false,
     transparent: true,
     backgroundColor: '#00000000',
-    icon: path.join(__dirname, 'media', 'AuraNote.ico'),
+    icon: path.join(__dirname, 'media', 'AuraNote.png'),
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       nodeIntegration: false,
@@ -78,6 +78,10 @@ function applyTheme(win, theme) {
       } else {
         win.setAcrylic();
       }
+      break;
+    case 'kurzgesagt':
+      win.setDarkTheme();
+      win.setMicaEffect();
       break;
     case 'dark-mica':
     default:

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <title>AuraNote</title>
-  <link rel="icon" href="../media/AuraNote.ico" type="image/x-icon" />
+  <link rel="icon" href="../media/AuraNote.png" type="image/png" />
   <link href="https://fonts.googleapis.com/css2?family=Poppins&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="../node_modules/@milkdown/theme-nord/lib/style.css" />
   <link rel="stylesheet" href="styles.css" />

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -162,11 +162,13 @@ const savedGradientOutline = localStorage.getItem('gradient-outline') || 'on';
 applyGradientOutline(savedGradientOutline === 'on', false);
 
 function applyTheme(theme, persist = true) {
-  document.body.classList.remove('theme-dark', 'theme-light', 'theme-acrylic');
+  document.body.classList.remove('theme-dark', 'theme-light', 'theme-acrylic', 'theme-kurzgesagt');
   if (theme === 'light-mica') {
     document.body.classList.add('theme-light');
   } else if (theme === 'acrylic') {
     document.body.classList.add('theme-acrylic');
+  } else if (theme === 'kurzgesagt') {
+    document.body.classList.add('theme-kurzgesagt');
   } else {
     document.body.classList.add('theme-dark');
   }

--- a/src/settings.html
+++ b/src/settings.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <title>AuraNote Settings</title>
-  <link rel="icon" href="../media/AuraNote.ico" type="image/x-icon" />
+  <link rel="icon" href="../media/AuraNote.png" type="image/png" />
   <link href="https://fonts.googleapis.com/css2?family=Poppins&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="../node_modules/@milkdown/theme-nord/lib/style.css" />
   <link rel="stylesheet" href="styles.css" />
@@ -45,6 +45,7 @@
                 <option value="dark-mica">Dark Mica</option>
                 <option value="light-mica">Light Mica</option>
                 <option value="acrylic">Acrylic</option>
+                <option value="kurzgesagt">Kurzgesagt</option>
               </select>
             </div>
             <div class="setting">

--- a/src/settings.js
+++ b/src/settings.js
@@ -43,11 +43,13 @@ function applyGradientOutline(enabled, persist = true) {
 }
 
 function applyTheme(theme, persist = true) {
-  document.body.classList.remove('theme-dark', 'theme-light', 'theme-acrylic');
+  document.body.classList.remove('theme-dark', 'theme-light', 'theme-acrylic', 'theme-kurzgesagt');
   if (theme === 'light-mica') {
     document.body.classList.add('theme-light');
   } else if (theme === 'acrylic') {
     document.body.classList.add('theme-acrylic');
+  } else if (theme === 'kurzgesagt') {
+    document.body.classList.add('theme-kurzgesagt');
   } else {
     document.body.classList.add('theme-dark');
   }

--- a/src/styles.css
+++ b/src/styles.css
@@ -76,6 +76,28 @@ body.theme-acrylic {
   --editor-pre-bg: rgba(0,0,0,0.4);
 }
 
+body.theme-kurzgesagt {
+  --text-color: #fff;
+  --titlebar-bg: rgba(20,24,46,0.9);
+  --main-bg: rgba(32,35,67,0.9);
+  --tab-hover-bg: rgba(255,255,255,0.1);
+  --tab-active-bg: #3da9fc;
+  --rename-bg: rgba(0,0,0,0.5);
+  --add-tab-hover-bg: rgba(255,255,255,0.1);
+  --add-tab-active-bg: rgba(255,255,255,0.2);
+  --note-bg: #23294f;
+  --settings-bg: rgba(32,35,67,0.85);
+  --select-bg: #23294f;
+  --select-text: #fff;
+  --select-border: #3da9fc;
+  --select-option-bg: #23294f;
+  --btn-hover-bg: rgba(61,169,252,0.3);
+  --scrollbar-thumb: rgba(61,169,252,0.5);
+  --scrollbar-thumb-hover: rgba(61,169,252,0.7);
+  --log-bg: rgba(12,15,30,0.9);
+  --editor-pre-bg: rgba(0,0,0,0.4);
+}
+
 body {
   font-family: var(--app-font);
   background: transparent;
@@ -334,7 +356,8 @@ body {
 }
 
 body.theme-dark .folder-icon svg,
-body.theme-acrylic .folder-icon svg {
+body.theme-acrylic .folder-icon svg,
+body.theme-kurzgesagt .folder-icon svg {
   fill: #fff;
 }
 


### PR DESCRIPTION
## Summary
- switch application icon to PNG for reliable display
- add new Kurzgesagt theme with dark palette and bright accents

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbec350f48832f88e4f18fae8cb804